### PR TITLE
Add OpenAI-powered terms analyzer web app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+OPENAI_API_KEY=your_openai_api_key_here
+PORT=3000

--- a/README.md
+++ b/README.md
@@ -1,0 +1,56 @@
+# Terms & Conditions Risk Analyzer
+
+A lightweight Express app that lets you submit the URL of any Terms & Conditions page. The server fetches the content, sends it to the OpenAI API for legal risk analysis, and returns a user-friendly summary of potential pitfalls.
+
+## Features
+
+- URL input form with a polished UI
+- Server-side scraping and text extraction with [cheerio](https://cheerio.js.org/)
+- Risk-focused prompt crafted for the OpenAI GPT-4o-mini model
+- Markdown rendering in the browser using [marked](https://marked.js.org/)
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 18+
+- An OpenAI API key with access to the specified model
+
+### Installation
+
+```bash
+npm install
+```
+
+### Configuration
+
+Copy the example environment file and add your OpenAI key:
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` with the correct values.
+
+### Running the App
+
+```bash
+npm run start
+```
+
+The app will be available at [http://localhost:3000](http://localhost:3000).
+
+During development you can use hot reloading for the server:
+
+```bash
+npm run dev
+```
+
+### Usage Notes
+
+- Some Terms & Conditions pages may block automated scraping or require JavaScript rendering; the server will report a descriptive error if it cannot fetch the page.
+- The OpenAI response is advisory only—consult a legal professional for binding guidance.
+
+## License
+
+MIT

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "terms-risk-analyzer",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "nodemon src/server.js",
+    "start": "node src/server.js"
+  },
+  "dependencies": {
+    "cheerio": "^1.0.0-rc.12",
+    "express": "^4.19.2",
+    "openai": "^4.52.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.0"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Terms &amp; Conditions Risk Analyzer</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <section class="card">
+        <h1>Terms &amp; Conditions Risk Analyzer</h1>
+        <p class="lead">
+          Paste the URL to any Terms &amp; Conditions page and let AI summarize the
+          risks in plain language.
+        </p>
+        <form id="analyze-form">
+          <label for="terms-url">Terms &amp; Conditions URL</label>
+          <div class="input-group">
+            <input
+              id="terms-url"
+              name="terms-url"
+              type="url"
+              placeholder="https://example.com/terms"
+              required
+            />
+            <button type="submit">Analyze</button>
+          </div>
+        </form>
+        <div id="status" class="status" role="status" aria-live="polite"></div>
+      </section>
+      <section class="card">
+        <h2>Analysis</h2>
+        <article id="analysis" class="analysis"></article>
+      </section>
+    </main>
+    <footer>
+      <p>
+        Powered by the OpenAI API. Please double-check results with a legal
+        professional before making decisions.
+      </p>
+    </footer>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script type="module" src="main.js"></script>
+  </body>
+</html>

--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,47 @@
+const form = document.getElementById("analyze-form");
+const urlInput = document.getElementById("terms-url");
+const statusEl = document.getElementById("status");
+const analysisEl = document.getElementById("analysis");
+
+function setStatus(message, isError = false) {
+  statusEl.textContent = message;
+  statusEl.classList.toggle("error", isError);
+}
+
+form.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const url = urlInput.value.trim();
+
+  if (!url) {
+    setStatus("Please enter a URL to analyze.", true);
+    return;
+  }
+
+  setStatus("Fetching the Terms & Conditions and asking OpenAI for insights...");
+  analysisEl.innerHTML = "";
+  form.querySelector("button").disabled = true;
+
+  try {
+    const response = await fetch("/api/analyze", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ url })
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      throw new Error(data.error || "Unknown error");
+    }
+
+    setStatus("Analysis complete.");
+    analysisEl.innerHTML = marked.parse(data.result);
+  } catch (error) {
+    console.error(error);
+    setStatus(error.message || "Something went wrong. Please try again.", true);
+  } finally {
+    form.querySelector("button").disabled = false;
+  }
+});

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,131 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  background: #f4f6fb;
+  color: #1f2933;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+main.app {
+  width: min(960px, 94vw);
+  display: grid;
+  gap: 1.5rem;
+  margin: 3rem auto 2rem auto;
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 18px;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+  padding: 2rem;
+  backdrop-filter: blur(8px);
+}
+
+h1,
+ h2 {
+  margin-top: 0;
+  color: #0f172a;
+}
+
+.lead {
+  margin-top: 0.5rem;
+  color: #475569;
+}
+
+form {
+  margin-top: 1.5rem;
+}
+
+label {
+  font-weight: 600;
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.input-group {
+  display: flex;
+  gap: 0.75rem;
+}
+
+input[type="url"] {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid #cbd5f5;
+  font-size: 1rem;
+  transition: border 0.2s, box-shadow 0.2s;
+}
+
+input[type="url"]:focus {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+  outline: none;
+}
+
+button {
+  background: linear-gradient(135deg, #6366f1, #3b82f6);
+  color: white;
+  border: none;
+  border-radius: 12px;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(59, 130, 246, 0.35);
+}
+
+.status {
+  margin-top: 1rem;
+  min-height: 1.5rem;
+  color: #334155;
+}
+
+.status.error {
+  color: #dc2626;
+}
+
+.analysis {
+  white-space: pre-wrap;
+  line-height: 1.55;
+  color: #1f2937;
+}
+
+footer {
+  margin-bottom: 2rem;
+  color: #64748b;
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+@media (max-width: 720px) {
+  .card {
+    padding: 1.5rem;
+  }
+
+  .input-group {
+    flex-direction: column;
+  }
+
+  button {
+    width: 100%;
+  }
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,100 @@
+import express from "express";
+import cheerio from "cheerio";
+import OpenAI from "openai";
+
+const PORT = process.env.PORT || 3000;
+
+const app = express();
+app.use(express.json({ limit: "1mb" }));
+app.use(express.static("public"));
+
+app.post("/api/analyze", async (req, res) => {
+  const { url } = req.body ?? {};
+
+  if (!process.env.OPENAI_API_KEY) {
+    return res.status(500).json({
+      error: "OPENAI_API_KEY is not set on the server."
+    });
+  }
+
+  if (!url || typeof url !== "string") {
+    return res.status(400).json({ error: "A valid 'url' field is required." });
+  }
+
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(url);
+  } catch (error) {
+    return res.status(400).json({ error: "Please provide a valid URL." });
+  }
+
+  try {
+    const response = await fetch(parsedUrl.toString(), {
+      headers: {
+        "User-Agent": "TermsRiskAnalyzer/1.0"
+      }
+    });
+
+    if (!response.ok) {
+      return res.status(502).json({
+        error: `Failed to retrieve the page (status ${response.status}).`
+      });
+    }
+
+    const html = await response.text();
+    const $ = cheerio.load(html);
+    const text = $("body")
+      .text()
+      .replace(/\s+/g, " ")
+      .trim();
+
+    if (!text) {
+      return res.status(422).json({
+        error: "Unable to extract readable text from the provided URL."
+      });
+    }
+
+    const maxLength = 12000;
+    const trimmed = text.length > maxLength ? `${text.slice(0, maxLength)}...` : text;
+
+    const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+    const messages = [
+      {
+        role: "system",
+        content:
+          "You are a legal expert specializing in highlighting risks hidden in online Terms and Conditions. Provide cautious, user-friendly explanations."
+      },
+      {
+        role: "user",
+        content: `Review the following Terms and Conditions text and identify any clauses that could pose risks to an everyday user. Prioritize limitations of liability, data sharing, subscription traps, automatic renewals, arbitration clauses, jurisdiction changes, and any unusual obligations.\n\nSummarize the most important findings in markdown with clear section headings for:\n- Overall Risk Summary\n- Highest-Risk Clauses\n- Medium-Risk Clauses\n- Notable User Rights or Protections\n\nFor each clause you highlight, include a short quote (at most 30 words) from the terms to justify your point. Use bullet lists where possible.\n\nHere is the text to analyze:\n\n${trimmed}`
+      }
+    ];
+
+    const completion = await client.chat.completions.create({
+      model: "gpt-4o-mini",
+      messages,
+      temperature: 0.2
+    });
+
+    const content = completion.choices[0]?.message?.content?.trim();
+
+    if (!content) {
+      return res.status(502).json({
+        error: "The analysis could not be generated. Please try again."
+      });
+    }
+
+    res.json({ result: content });
+  } catch (error) {
+    console.error("Analysis error", error);
+    res.status(500).json({
+      error: "An unexpected error occurred while analyzing the terms.",
+      details: error.message
+    });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Terms risk analyzer running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- set up an Express server that fetches terms text, calls the OpenAI API, and returns a risk-focused markdown summary
- add a polished frontend form that submits a terms URL and renders the analysis with Markdown support
- document project setup, environment configuration, and usage notes

## Testing
- npm install *(fails in CI due to 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e986d2948320835117847fb89c4c