### PR TITLE
Use cheerio load helper with named import

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,5 @@
 import express from "express";
-import cheerio from "cheerio";
+import { load } from "cheerio";
 import OpenAI from "openai";
 
 const PORT = process.env.PORT || 3000;
@@ -42,7 +42,7 @@ app.post("/api/analyze", async (req, res) => {
     }
 
     const html = await response.text();
-    const $ = cheerio.load(html);
+    const $ = load(html);
     const text = $("body")
       .text()
       .replace(/\s+/g, " ")


### PR DESCRIPTION
## Summary
- switch the cheerio import to use the `load` named export
- update HTML parsing to call the `load` helper directly

## Testing
- `node src/server.js` *(fails: missing dependencies in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7f1d495cc8320ac66c2103c45e190