### PR TITLE
Add landing page and demo login

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,31 +7,93 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <main class="app">
-      <section class="card">
+    <header class="hero">
+      <div class="hero-content">
+        <p class="badge">New</p>
         <h1>Terms &amp; Conditions Risk Analyzer</h1>
         <p class="lead">
-          Paste the URL to any Terms &amp; Conditions page and let AI summarize the
-          risks in plain language.
+          Understand the fine print before you click “I agree”. Paste any
+          policy URL and our AI will surface the clauses that deserve a closer
+          look.
         </p>
-        <form id="analyze-form">
-          <label for="terms-url">Terms &amp; Conditions URL</label>
-          <div class="input-group">
-            <input
-              id="terms-url"
-              name="terms-url"
-              type="url"
-              placeholder="https://example.com/terms"
-              required
-            />
-            <button type="submit">Analyze</button>
-          </div>
+        <ul class="feature-list">
+          <li>🔍 Pinpoints liability traps, auto-renewals, and data sharing</li>
+          <li>🛡️ Highlights user protections worth knowing about</li>
+          <li>⚡ Generates a readable summary in seconds</li>
+        </ul>
+      </div>
+    </header>
+    <main class="layout">
+      <section id="login-section" class="card auth-card" aria-labelledby="login-title">
+        <h2 id="login-title">Sign in to explore the analyzer</h2>
+        <p class="muted">
+          Use the shared demo credentials to unlock the analysis workspace.
+        </p>
+        <div class="credentials">
+          <p>
+            <strong>Username:</strong> <code>demo</code>
+          </p>
+          <p>
+            <strong>Password:</strong> <code>opensesame</code>
+          </p>
+        </div>
+        <form id="login-form" autocomplete="on">
+          <label for="username">Username</label>
+          <input
+            id="username"
+            name="username"
+            type="text"
+            inputmode="text"
+            autocomplete="username"
+            required
+          />
+          <label for="password">Password</label>
+          <input
+            id="password"
+            name="password"
+            type="password"
+            autocomplete="current-password"
+            required
+          />
+          <button type="submit">Sign in</button>
         </form>
-        <div id="status" class="status" role="status" aria-live="polite"></div>
+        <div
+          id="login-status"
+          class="status"
+          role="status"
+          aria-live="polite"
+        ></div>
       </section>
-      <section class="card">
-        <h2>Analysis</h2>
-        <article id="analysis" class="analysis"></article>
+      <section id="app-section" class="app hidden" aria-live="polite">
+        <div class="card card-tight">
+          <div class="app-header">
+            <div>
+              <h2>Analyze a policy</h2>
+              <p class="muted">Paste the Terms &amp; Conditions URL to begin.</p>
+            </div>
+            <button type="button" class="secondary" id="logout-button">
+              Log out
+            </button>
+          </div>
+          <form id="analyze-form">
+            <label for="terms-url">Terms &amp; Conditions URL</label>
+            <div class="input-group">
+              <input
+                id="terms-url"
+                name="terms-url"
+                type="url"
+                placeholder="https://example.com/terms"
+                required
+              />
+              <button type="submit">Analyze</button>
+            </div>
+          </form>
+          <div id="status" class="status" role="status" aria-live="polite"></div>
+        </div>
+        <div class="card">
+          <h2>Analysis</h2>
+          <article id="analysis" class="analysis"></article>
+        </div>
       </section>
     </main>
     <footer>

--- a/public/main.js
+++ b/public/main.js
@@ -1,16 +1,130 @@
+const TOKEN_KEY = "tra-auth-token";
+
 const form = document.getElementById("analyze-form");
 const urlInput = document.getElementById("terms-url");
 const statusEl = document.getElementById("status");
 const analysisEl = document.getElementById("analysis");
+const loginSection = document.getElementById("login-section");
+const appSection = document.getElementById("app-section");
+const loginForm = document.getElementById("login-form");
+const loginStatusEl = document.getElementById("login-status");
+const logoutButton = document.getElementById("logout-button");
+
+let authToken = localStorage.getItem(TOKEN_KEY) ?? "";
+
+function setLoginStatus(message = "", isError = false) {
+  if (!loginStatusEl) return;
+  loginStatusEl.textContent = message;
+  loginStatusEl.classList.toggle("error", isError);
+}
 
 function setStatus(message, isError = false) {
+  if (!statusEl) return;
   statusEl.textContent = message;
   statusEl.classList.toggle("error", isError);
 }
 
-form.addEventListener("submit", async (event) => {
+function showApp() {
+  loginSection?.classList.add("hidden");
+  appSection?.classList.remove("hidden");
+  setLoginStatus("");
+  setStatus("Paste the Terms & Conditions URL to begin.");
+}
+
+function showLogin(message = "", isError = false) {
+  loginSection?.classList.remove("hidden");
+  appSection?.classList.add("hidden");
+  if (message) {
+    setLoginStatus(message, isError);
+  } else {
+    setLoginStatus("Use the demo credentials above to sign in.");
+  }
+  form?.reset();
+  if (analysisEl) {
+    analysisEl.innerHTML = "";
+  }
+  setStatus("");
+}
+
+function handleUnauthorized(message = "Your session expired. Please sign in again.") {
+  authToken = "";
+  localStorage.removeItem(TOKEN_KEY);
+  showLogin(message, true);
+}
+
+if (authToken) {
+  showApp();
+} else {
+  showLogin();
+}
+
+loginForm?.addEventListener("submit", async (event) => {
   event.preventDefault();
-  const url = urlInput.value.trim();
+  const formData = new FormData(loginForm);
+  const username = formData.get("username")?.toString().trim();
+  const password = formData.get("password")?.toString() ?? "";
+
+  if (!username || !password) {
+    setLoginStatus("Please provide both a username and password.", true);
+    return;
+  }
+
+  setLoginStatus("Signing you in...");
+
+  try {
+    const response = await fetch("/api/login", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ username, password })
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      throw new Error(data.error || "Unable to sign in.");
+    }
+
+    authToken = data.token;
+    localStorage.setItem(TOKEN_KEY, authToken);
+    setLoginStatus("Login successful!");
+    showApp();
+  } catch (error) {
+    console.error(error);
+    setLoginStatus(error.message || "Unable to sign in.", true);
+  }
+});
+
+logoutButton?.addEventListener("click", async () => {
+  if (!authToken) {
+    showLogin();
+    return;
+  }
+
+  try {
+    await fetch("/api/logout", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${authToken}`
+      }
+    });
+  } catch (error) {
+    console.error(error);
+  } finally {
+    handleUnauthorized("You have been signed out.");
+  }
+});
+
+form?.addEventListener("submit", async (event) => {
+  event.preventDefault();
+
+  if (!authToken) {
+    handleUnauthorized();
+    return;
+  }
+
+  const url = urlInput?.value.trim();
 
   if (!url) {
     setStatus("Please enter a URL to analyze.", true);
@@ -18,30 +132,46 @@ form.addEventListener("submit", async (event) => {
   }
 
   setStatus("Fetching the Terms & Conditions and asking OpenAI for insights...");
-  analysisEl.innerHTML = "";
-  form.querySelector("button").disabled = true;
+  if (analysisEl) {
+    analysisEl.innerHTML = "";
+  }
+
+  const submitButton = form.querySelector("button[type='submit']");
+  if (submitButton) {
+    submitButton.disabled = true;
+  }
 
   try {
     const response = await fetch("/api/analyze", {
       method: "POST",
       headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${authToken}`
       },
       body: JSON.stringify({ url })
     });
 
     const data = await response.json();
 
+    if (response.status === 401) {
+      handleUnauthorized();
+      return;
+    }
+
     if (!response.ok) {
       throw new Error(data.error || "Unknown error");
     }
 
     setStatus("Analysis complete.");
-    analysisEl.innerHTML = marked.parse(data.result);
+    if (analysisEl) {
+      analysisEl.innerHTML = marked.parse(data.result);
+    }
   } catch (error) {
     console.error(error);
     setStatus(error.message || "Something went wrong. Please try again.", true);
   } finally {
-    form.querySelector("button").disabled = false;
+    if (submitButton) {
+      submitButton.disabled = false;
+    }
   }
 });

--- a/public/styles.css
+++ b/public/styles.css
@@ -11,14 +11,34 @@ body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
 }
 
-main.app {
-  width: min(960px, 94vw);
-  display: grid;
-  gap: 1.5rem;
-  margin: 3rem auto 2rem auto;
+
+.hero {
+  background: radial-gradient(circle at top left, #6366f1 0%, #3b82f6 38%, #1f2937 100%);
+  color: #f8fafc;
+  padding: clamp(3rem, 8vw, 5rem) clamp(1.5rem, 6vw, 6rem);
+  text-align: left;
+}
+
+.hero-content {
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  margin-bottom: 1rem;
 }
 
 .card {
@@ -30,14 +50,55 @@ main.app {
 }
 
 h1,
- h2 {
+h2 {
   margin-top: 0;
-  color: #0f172a;
+  color: inherit;
 }
 
 .lead {
-  margin-top: 0.5rem;
+  margin-top: 0.75rem;
+  color: #e2e8f0;
+  font-size: 1.1rem;
+}
+
+.muted {
   color: #475569;
+  margin-top: 0.5rem;
+}
+
+.feature-list {
+  list-style: none;
+  margin: 2rem 0 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+  font-size: 1.05rem;
+  color: rgba(226, 232, 240, 0.92);
+}
+
+.layout {
+  width: min(960px, 94vw);
+  margin: clamp(2rem, 6vw, 4rem) auto 2.5rem auto;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.app {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.card-tight {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
 }
 
 form {
@@ -55,6 +116,8 @@ label {
   gap: 0.75rem;
 }
 
+input[type="text"],
+input[type="password"],
 input[type="url"] {
   flex: 1;
   padding: 0.75rem 1rem;
@@ -64,6 +127,8 @@ input[type="url"] {
   transition: border 0.2s, box-shadow 0.2s;
 }
 
+input[type="text"]:focus,
+input[type="password"]:focus,
 input[type="url"]:focus {
   border-color: #6366f1;
   box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
@@ -80,6 +145,18 @@ button {
   font-weight: 600;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.secondary {
+  background: rgba(99, 102, 241, 0.1);
+  color: #4338ca;
+  box-shadow: none;
+}
+
+.secondary:hover {
+  box-shadow: none;
+  background: rgba(99, 102, 241, 0.18);
+  transform: none;
 }
 
 button:disabled {
@@ -109,6 +186,29 @@ button:not(:disabled):hover {
   color: #1f2937;
 }
 
+.credentials {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 2rem;
+  padding: 1rem 1.25rem;
+  background: rgba(99, 102, 241, 0.08);
+  border-radius: 14px;
+  margin: 1.25rem 0 0 0;
+  font-size: 0.95rem;
+}
+
+code {
+  background: rgba(148, 163, 184, 0.25);
+  padding: 0.1rem 0.4rem;
+  border-radius: 8px;
+  font-family: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular,
+    Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+.hidden {
+  display: none !important;
+}
+
 footer {
   margin-bottom: 2rem;
   color: #64748b;
@@ -117,6 +217,15 @@ footer {
 }
 
 @media (max-width: 720px) {
+  .hero {
+    padding: 2.5rem 1.25rem 2rem 1.25rem;
+    text-align: left;
+  }
+
+  .badge {
+    margin-bottom: 0.75rem;
+  }
+
   .card {
     padding: 1.5rem;
   }
@@ -127,5 +236,10 @@ footer {
 
   button {
     width: 100%;
+  }
+
+  .app-header {
+    flex-direction: column;
+    align-items: stretch;
   }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -1,14 +1,81 @@
 import express from "express";
 import { load } from "cheerio";
 import OpenAI from "openai";
+import crypto from "crypto";
 
 const PORT = process.env.PORT || 3000;
+
+const TEST_CREDENTIALS = {
+  username: "demo",
+  password: "opensesame"
+};
+
+const activeTokens = new Set();
 
 const app = express();
 app.use(express.json({ limit: "1mb" }));
 app.use(express.static("public"));
 
-app.post("/api/analyze", async (req, res) => {
+function extractToken(req) {
+  const authHeader = req.get("authorization");
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    return null;
+  }
+
+  return authHeader.slice("Bearer ".length).trim();
+}
+
+function requireAuth(req, res, next) {
+  const token = extractToken(req);
+
+  if (!token || !activeTokens.has(token)) {
+    return res.status(401).json({
+      error: "Unauthorized. Please log in again."
+    });
+  }
+
+  req.token = token;
+  next();
+}
+
+app.post("/api/login", (req, res) => {
+  const { username, password } = req.body ?? {};
+
+  if (
+    typeof username !== "string" ||
+    typeof password !== "string" ||
+    username.trim() !== TEST_CREDENTIALS.username ||
+    password !== TEST_CREDENTIALS.password
+  ) {
+    return res.status(401).json({ error: "Invalid username or password." });
+  }
+
+  const token = crypto.randomUUID();
+  activeTokens.add(token);
+
+  res.json({
+    token,
+    message: "Login successful."
+  });
+});
+
+app.post("/api/logout", (req, res) => {
+  const token = extractToken(req);
+
+  if (!token) {
+    return res
+      .status(400)
+      .json({ error: "A valid authorization token is required to log out." });
+  }
+
+  if (activeTokens.delete(token)) {
+    return res.json({ success: true });
+  }
+
+  return res.status(400).json({ error: "The provided session is not active." });
+});
+
+app.post("/api/analyze", requireAuth, async (req, res) => {
   const { url } = req.body ?? {};
 
   if (!process.env.OPENAI_API_KEY) {


### PR DESCRIPTION
## Summary
- add a marketing-focused landing hero with demo credentials and sign-in form
- gate the analyzer behind a simple login backed by token-based routes on the server
- refresh the client-side logic and styling to handle authentication, logout, and the new layout

## Testing
- node --check src/server.js

------
https://chatgpt.com/codex/tasks/task_e_68d8084ed8cc83209fb7d718d1a3092a