### PR TITLE
Add session-based analysis history

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -65,7 +65,7 @@
         ></div>
       </section>
       <section id="app-section" class="app hidden" aria-live="polite">
-        <div class="card card-tight">
+        <div class="card card-tight card-wide">
           <div class="app-header">
             <div>
               <h2>Analyze a policy</h2>
@@ -89,6 +89,19 @@
             </div>
           </form>
           <div id="status" class="status" role="status" aria-live="polite"></div>
+        </div>
+        <div class="card history-card">
+          <div class="history-header">
+            <h2>Recent analyses</h2>
+            <p class="muted small">
+              Revisit previously reviewed policies from this session.
+            </p>
+          </div>
+          <div id="history-empty" class="history-empty muted">
+            No analyses yet. Your history will appear here after you review a
+            policy.
+          </div>
+          <ul id="history-list" class="history-list" aria-live="polite"></ul>
         </div>
         <div class="card">
           <h2>Analysis</h2>

--- a/public/main.js
+++ b/public/main.js
@@ -9,8 +9,96 @@ const appSection = document.getElementById("app-section");
 const loginForm = document.getElementById("login-form");
 const loginStatusEl = document.getElementById("login-status");
 const logoutButton = document.getElementById("logout-button");
+const historyListEl = document.getElementById("history-list");
+const historyEmptyEl = document.getElementById("history-empty");
 
 let authToken = localStorage.getItem(TOKEN_KEY) ?? "";
+let historyItems = [];
+
+function generateId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  return `history-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function renderHistory() {
+  if (!historyListEl || !historyEmptyEl) return;
+
+  historyListEl.innerHTML = "";
+
+  if (!historyItems.length) {
+    historyEmptyEl.classList.remove("hidden");
+    return;
+  }
+
+  historyEmptyEl.classList.add("hidden");
+
+  for (const item of historyItems) {
+    const li = document.createElement("li");
+    li.className = "history-item";
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "history-button";
+    button.dataset.historyId = item.id;
+
+    const title = document.createElement("div");
+    title.textContent = formatHistoryTitle(item.url);
+
+    const meta = document.createElement("div");
+    meta.className = "history-meta";
+    meta.textContent = formatHistoryTimestamp(item.analyzedAt);
+
+    button.append(title, meta);
+    li.append(button);
+    historyListEl.append(li);
+  }
+}
+
+function formatHistoryTitle(url) {
+  if (!url) {
+    return "Unknown policy";
+  }
+
+  try {
+    const parsed = new URL(url);
+    const path = parsed.pathname === "/" ? "" : parsed.pathname;
+    const display = `${parsed.hostname}${path}`;
+    return display.length > 60 ? `${display.slice(0, 57)}…` : display;
+  } catch (error) {
+    return url.length > 60 ? `${url.slice(0, 57)}…` : url;
+  }
+}
+
+function formatHistoryTimestamp(timestamp) {
+  if (!timestamp) return "Unknown time";
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return "Unknown time";
+  }
+
+  return date.toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short"
+  });
+}
+
+function setHistory(items) {
+  historyItems = Array.isArray(items) ? items : [];
+  renderHistory();
+}
+
+function upsertHistoryItem(item) {
+  if (!item || !item.id) return;
+  const filtered = historyItems.filter((entry) => entry.id !== item.id);
+  historyItems = [item, ...filtered];
+  if (historyItems.length > 10) {
+    historyItems.length = 10;
+  }
+  renderHistory();
+}
 
 function setLoginStatus(message = "", isError = false) {
   if (!loginStatusEl) return;
@@ -44,6 +132,7 @@ function showLogin(message = "", isError = false) {
     analysisEl.innerHTML = "";
   }
   setStatus("");
+  setHistory([]);
 }
 
 function handleUnauthorized(message = "Your session expired. Please sign in again.") {
@@ -54,6 +143,7 @@ function handleUnauthorized(message = "Your session expired. Please sign in agai
 
 if (authToken) {
   showApp();
+  refreshHistory();
 } else {
   showLogin();
 }
@@ -90,6 +180,7 @@ loginForm?.addEventListener("submit", async (event) => {
     localStorage.setItem(TOKEN_KEY, authToken);
     setLoginStatus("Login successful!");
     showApp();
+    await refreshHistory();
   } catch (error) {
     console.error(error);
     setLoginStatus(error.message || "Unable to sign in.", true);
@@ -114,6 +205,50 @@ logoutButton?.addEventListener("click", async () => {
   } finally {
     handleUnauthorized("You have been signed out.");
   }
+});
+
+async function refreshHistory() {
+  if (!authToken || !historyListEl) return;
+
+  try {
+    const response = await fetch("/api/history", {
+      headers: {
+        Authorization: `Bearer ${authToken}`
+      }
+    });
+
+    if (response.status === 401) {
+      handleUnauthorized();
+      return;
+    }
+
+    const data = await response.json();
+    if (Array.isArray(data.history)) {
+      setHistory(data.history);
+    } else {
+      setHistory([]);
+    }
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+historyListEl?.addEventListener("click", (event) => {
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) return;
+  const button = target.closest("button[data-history-id]");
+  if (!button) return;
+
+  const { historyId } = button.dataset;
+  if (!historyId) return;
+
+  const item = historyItems.find((entry) => entry.id === historyId);
+  if (!item) return;
+
+  if (analysisEl) {
+    analysisEl.innerHTML = marked.parse(item.result ?? "");
+  }
+  setStatus(`Showing saved analysis from ${formatHistoryTimestamp(item.analyzedAt)}.`);
 });
 
 form?.addEventListener("submit", async (event) => {
@@ -165,6 +300,16 @@ form?.addEventListener("submit", async (event) => {
     setStatus("Analysis complete.");
     if (analysisEl) {
       analysisEl.innerHTML = marked.parse(data.result);
+    }
+    if (data.analysis) {
+      upsertHistoryItem(data.analysis);
+    } else {
+      upsertHistoryItem({
+        id: generateId(),
+        url,
+        analyzedAt: new Date().toISOString(),
+        result: data.result
+      });
     }
   } catch (error) {
     console.error(error);

--- a/public/styles.css
+++ b/public/styles.css
@@ -86,6 +86,12 @@ h2 {
 .app {
   display: grid;
   gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: start;
+}
+
+.card-wide {
+  grid-column: 1 / -1;
 }
 
 .card-tight {
@@ -184,6 +190,67 @@ button:not(:disabled):hover {
   white-space: pre-wrap;
   line-height: 1.55;
   color: #1f2937;
+}
+
+.small {
+  font-size: 0.9rem;
+}
+
+.history-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.history-header h2 {
+  margin-bottom: 0.25rem;
+}
+
+.history-empty {
+  font-style: italic;
+}
+
+.history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.history-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.history-button {
+  all: unset;
+  cursor: pointer;
+  display: block;
+  padding: 0.75rem 0.85rem;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  background: rgba(99, 102, 241, 0.08);
+  transition: border 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.history-button:hover,
+.history-button:focus-visible {
+  border-color: rgba(99, 102, 241, 0.5);
+  background: rgba(99, 102, 241, 0.12);
+  transform: translateY(-1px);
+}
+
+.history-button:focus-visible {
+  outline: 2px solid rgba(99, 102, 241, 0.4);
+  outline-offset: 3px;
+}
+
+.history-meta {
+  color: #475569;
+  font-size: 0.85rem;
 }
 
 .credentials {

--- a/src/server.js
+++ b/src/server.js
@@ -11,6 +11,7 @@ const TEST_CREDENTIALS = {
 };
 
 const activeTokens = new Set();
+const analysisHistory = new Map();
 
 const app = express();
 app.use(express.json({ limit: "1mb" }));
@@ -69,6 +70,7 @@ app.post("/api/logout", (req, res) => {
   }
 
   if (activeTokens.delete(token)) {
+    analysisHistory.delete(token);
     return res.json({ success: true });
   }
 
@@ -152,7 +154,18 @@ app.post("/api/analyze", requireAuth, async (req, res) => {
       });
     }
 
-    res.json({ result: content });
+    const analysisRecord = {
+      id: crypto.randomUUID(),
+      url: parsedUrl.toString(),
+      analyzedAt: new Date().toISOString(),
+      result: content
+    };
+
+    const history = analysisHistory.get(req.token) ?? [];
+    history.unshift(analysisRecord);
+    analysisHistory.set(req.token, history.slice(0, 10));
+
+    res.json({ result: content, analysis: analysisRecord });
   } catch (error) {
     console.error("Analysis error", error);
     res.status(500).json({
@@ -160,6 +173,11 @@ app.post("/api/analyze", requireAuth, async (req, res) => {
       details: error.message
     });
   }
+});
+
+app.get("/api/history", requireAuth, (req, res) => {
+  const history = analysisHistory.get(req.token) ?? [];
+  res.json({ history });
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- store recent analyses per session on the server and expose them via a new `/api/history` endpoint
- update the client to fetch, render, and interact with a history of analyzed policies
- refresh the layout and styles to accommodate the new history card and improve responsiveness

## Testing
- npm run start *(fails: missing local dependencies because npm install cannot run in this environment)*
- npm install *(fails: registry access is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d82ab3e22c8320a7bf1562f37b3c84